### PR TITLE
RIA-7378 - preventing application startup if secrets can't be found

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -16,10 +16,17 @@ def gradleBuilder = new GradleBuilder(this, product)
 
 def branchesToSync = ['demo']
 
+def secrets = [
+  'ia-${env}': [
+    secret('ia-config-validator-secret', 'IA_CONFIG_VALIDATOR_SECRET')
+  ]
+]
+
 withPipeline(type, product, component) {
     enableAksStagingDeployment()
     disableLegacyDeployment()
     nonServiceApp()
     syncBranchesWithMaster(branchesToSync)
+    loadVaultSecrets(secrets)
 }
 

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -11,4 +11,12 @@ def type = "java"
 def product = "ia"
 def component = "case-migration"
 
-withNightlyPipeline(type, product, component) {}
+def secrets = [
+  'ia-${env}': [
+    secret('ia-config-validator-secret', 'IA_CONFIG_VALIDATOR_SECRET')
+  ]
+]
+
+withNightlyPipeline(type, product, component) {
+  loadVaultSecrets(secrets)
+}

--- a/charts/ia-case-migration/values.yaml
+++ b/charts/ia-case-migration/values.yaml
@@ -37,3 +37,5 @@ java:
           alias: LAUNCH_DARKLY_SDK_KEY
         - name: AppInsightsInstrumentationKey
           alias: azure.application-insights.instrumentation-key
+        - name: ia-config-validator-secret
+          alias: IA_CONFIG_VALIDATOR_SECRET

--- a/src/main/java/uk/gov/hmcts/reform/iacasemigration/infrastructure/ConfigValidatorAppListener.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasemigration/infrastructure/ConfigValidatorAppListener.java
@@ -4,9 +4,11 @@ import com.microsoft.applicationinsights.boot.dependencies.apachecommons.lang3.S
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,6 +16,11 @@ import org.springframework.stereotype.Component;
 @Getter
 @Setter
 public class ConfigValidatorAppListener implements ApplicationListener<ContextRefreshedEvent> {
+
+    protected static final String CLUSTER_NAME = "CLUSTER_NAME";
+
+    @Autowired
+    private Environment environment;
 
     @Value("${ia.config.validator.secret}")
     private String iaConfigValidatorSecret;
@@ -24,12 +31,19 @@ public class ConfigValidatorAppListener implements ApplicationListener<ContextRe
     }
 
     void breakOnMissingIaConfigValidatorSecret() {
+        String clusterName = environment.getProperty(CLUSTER_NAME);
+        log.info("{} value: {}", CLUSTER_NAME, clusterName);
+        if (StringUtils.isBlank(clusterName)) {
+            log.warn("{} is null or empty. Skipping this check. This is allowed on a developer's local environment "
+                + "but not on a cluster. If you are in a cluster, this warning is going to be a problem.", CLUSTER_NAME);
+            return;
+        }
+
         if (StringUtils.isBlank(iaConfigValidatorSecret)) {
-            log.info("IA Config Validator Secret Value: {}", iaConfigValidatorSecret);
             throw new IllegalArgumentException("ia.config.validator.secret is null or empty."
                 + " This is not allowed and it will break production. This is a secret value stored in a vault"
                 + " (unless running locally). Check application.yaml for further information.");
-
         }
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasemigration/infrastructure/ConfigValidatorAppListener.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasemigration/infrastructure/ConfigValidatorAppListener.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.reform.iacasemigration.infrastructure;
+
+import com.microsoft.applicationinsights.boot.dependencies.apachecommons.lang3.StringUtils;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@Getter
+@Setter
+public class ConfigValidatorAppListener implements ApplicationListener<ContextRefreshedEvent> {
+
+    @Value("${ia.config.validator.secret}")
+    private String iaConfigValidatorSecret;
+
+    @Override
+    public void onApplicationEvent(ContextRefreshedEvent event) {
+        breakOnMissingIaConfigValidatorSecret();
+    }
+
+    void breakOnMissingIaConfigValidatorSecret() {
+        if (StringUtils.isBlank(iaConfigValidatorSecret)) {
+            log.info("IA Config Validator Secret Value: {}", iaConfigValidatorSecret);
+            throw new IllegalArgumentException("ia.config.validator.secret is null or empty."
+                + " This is not allowed and it will break production. This is a secret value stored in a vault"
+                + " (unless running locally). Check application.yaml for further information.");
+
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,3 +34,5 @@ migration.pageSize: 400
 migration.numThreads: 7
 migration.maxCasesToProcess: 0
 migration.migrateCaseNameInternal: true
+
+ia.config.validator.secret: ${IA_CONFIG_VALIDATOR_SECRET:}

--- a/src/test/java/uk/gov/hmcts/reform/iacasemigration/infrastructure/ConfigValidatorAppListenerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasemigration/infrastructure/ConfigValidatorAppListenerTest.java
@@ -1,45 +1,108 @@
 package uk.gov.hmcts.reform.iacasemigration.infrastructure;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasemigration.infrastructure.ConfigValidatorAppListener.CLUSTER_NAME;
 
 @ExtendWith(MockitoExtension.class)
 class ConfigValidatorAppListenerTest {
 
+    @Mock
+    private Environment env;
+
+    private ConfigValidatorAppListener configValidatorAppListener;
+
+    @BeforeEach
+    public void setup() {
+        configValidatorAppListener = new ConfigValidatorAppListener();
+        configValidatorAppListener.setEnvironment(env);
+    }
+
     @Test
-    void throwsExceptionWhenIaConfigValidatorSecretIsNull() {
+    @SuppressWarnings("java:S2699")
+    void throwsExceptionWhenIaConfigValidatorSecretIsNullSimulateLocal() {
         // Given
-        ConfigValidatorAppListener configValidatorAppListener = new ConfigValidatorAppListener();
         configValidatorAppListener.setIaConfigValidatorSecret(null);
-
-        // When/Then
-        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
-    }
-
-    @Test
-    void throwsExceptionWhenIaConfigValidatorSecretIsEmpty() {
-        // Given
-        ConfigValidatorAppListener configValidatorAppListener = new ConfigValidatorAppListener();
-        configValidatorAppListener.setIaConfigValidatorSecret("");
-
-        // When/Then
-        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
-    }
-
-    @Test
-    @SuppressWarnings("java:S2699") // suppressing SonarLint warning on assertions as it's ok for this test not to have any
-    void runsSuccessfullyWhenIaConfigValidatorSecretsAreCorrectlySet() {
-        // Given
-        ConfigValidatorAppListener configValidatorAppListener = new ConfigValidatorAppListener();
-        configValidatorAppListener.setIaConfigValidatorSecret("secret");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn(null);
 
         // When
         configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
 
         // Then
+        verify(env).getProperty(CLUSTER_NAME);
+    }
+
+    @Test
+    void throwsExceptionWhenIaConfigValidatorSecretIsNullSimulateCluster() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret(null);
+        when(env.getProperty(CLUSTER_NAME)).thenReturn("cft-preview-01-aks");
+
+        // When/Then
+        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
+        verify(env).getProperty(CLUSTER_NAME);
+    }
+
+    @Test
+    void throwsExceptionWhenIaConfigValidatorSecretIsEmptySimulateLocal() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret("");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn(null);
+
+        // When
+        configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
+
+        // Then
+        verify(env).getProperty(CLUSTER_NAME);
+    }
+
+    @Test
+    void throwsExceptionWhenIaConfigValidatorSecretIsEmptySimulateCluster() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret("");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn("cft-preview-01-aks");
+
+
+        // When/Then
+        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
+        verify(env).getProperty(CLUSTER_NAME);
+    }
+
+    @Test
+    @SuppressWarnings("java:S2699") // suppressing SonarLint warning on assertions as it's ok for this test not to have any
+    void runsSuccessfullyWhenIaConfigValidatorSecretsAreCorrectlySetSimulateLocal() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret("secret");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn(null);
+
+        // When
+        configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
+
+        // Then
+        verify(env).getProperty(CLUSTER_NAME);
+        // I run successfully till the end
+    }
+
+    @Test
+    @SuppressWarnings("java:S2699") // suppressing SonarLint warning on assertions as it's ok for this test not to have any
+    void runsSuccessfullyWhenIaConfigValidatorSecretsAreCorrectlySetSimulateCluster() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret("secret");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn("cft-preview-01-aks");
+
+        // When
+        configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
+
+        // Then
+        verify(env).getProperty(CLUSTER_NAME);
         // I run successfully till the end
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iacasemigration/infrastructure/ConfigValidatorAppListenerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasemigration/infrastructure/ConfigValidatorAppListenerTest.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.reform.iacasemigration.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+class ConfigValidatorAppListenerTest {
+
+    @Test
+    void throwsExceptionWhenIaConfigValidatorSecretIsNull() {
+        // Given
+        ConfigValidatorAppListener configValidatorAppListener = new ConfigValidatorAppListener();
+        configValidatorAppListener.setIaConfigValidatorSecret(null);
+
+        // When/Then
+        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
+    }
+
+    @Test
+    void throwsExceptionWhenIaConfigValidatorSecretIsEmpty() {
+        // Given
+        ConfigValidatorAppListener configValidatorAppListener = new ConfigValidatorAppListener();
+        configValidatorAppListener.setIaConfigValidatorSecret("");
+
+        // When/Then
+        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
+    }
+
+    @Test
+    @SuppressWarnings("java:S2699") // suppressing SonarLint warning on assertions as it's ok for this test not to have any
+    void runsSuccessfullyWhenIaConfigValidatorSecretsAreCorrectlySet() {
+        // Given
+        ConfigValidatorAppListener configValidatorAppListener = new ConfigValidatorAppListener();
+        configValidatorAppListener.setIaConfigValidatorSecret("secret");
+
+        // When
+        configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
+
+        // Then
+        // I run successfully till the end
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7383


### Change description ###
Adding ia.config.validator.secret to application.yaml + ConfigValidatorAppListener to check to see if secrets are being applied by azure.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
